### PR TITLE
Feature: Use a lightweight base Docker image.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.github
+.git
+.dockerignore
+.gitignore
+etcd-browser.service
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,4 @@
-FROM ubuntu:14.04
-
-MAINTAINER Christoph Wiechert <wio@psitrax.de>
-MAINTAINER https://github.com/henszey
-
-RUN apt-get update
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get install -y nodejs
+FROM node:lts-alpine
 
 RUN mkdir /app
 ADD . /app/


### PR DESCRIPTION
- Replace `ubuntu` base image with `node:lts-alpine`.
- Avoid copying un-needed files into generated Docker image.