### PR TITLE
Fix: Path Traversal and DoS on certain requests

### DIFF
--- a/server.js
+++ b/server.js
@@ -52,33 +52,56 @@ http.createServer(function serverFile(req, res) {
         return;
     }
 
-    if (req.url === '/') {
-        req.url = '/index.html';
-    } else if (req.url.substr(0, 3) === '/v2') {
+    if (req.url.substr(0, 3) === '/v2') { // api request
         // avoid fileExists for /v2 routes
         return proxy(req, res);
-    } else {
+    } else { // statics request
+        if (req.url === '/')
+            req.url = '/index.html';
         var uri = url.parse(req.url).pathname;
         var filename = path.join(process.cwd(), publicDir, path.normalize(uri));
 
-        fs.exists(filename, function (exists) {
-            // returns 404 if file does not exist.
-            if (!exists) {
-                res.writeHead(404, {"Content-Type": 'text/html'});
-                res.end("<!DOCTYPE html><html><head><meta charset=\"utf-8\"/><title>Not Found</title></head><body><h1>Not Found</h1><p>The requested file is not found on this server.</p></body></html>");
+        function send_not_found(res) {
+            var not_found_html = "<!DOCTYPE html><html><head><meta charset=\"utf-8\"/><title>Not Found</title></head><body><h1>Not Found</h1><p>The requested file is not found on this server.</p></body></html>";
+            res.writeHead(404, {
+                "Content-Type": "text/html",
+                "Content-Length": not_found_html.length
+            });
+            res.end(not_found_html);
+        }
+
+        fs.stat(filename, function (err, stats) {
+            if (err) { // file does not exist.
+                send_not_found(res);
                 return;
             }
 
-            fs_ext = path.extname(filename).split(".")[1];
-            if (!mimeTypes[fs_ext]) { // raise 404 if ext not supported.
-                res.writeHead(404, {"Content-Type": 'text/html'});
-                res.end("<!DOCTYPE html><html><head><meta charset=\"utf-8\"/><title>Not Found</title></head><body><h1>Not Found</h1><p>The requested file is not found on this server.</p></body></html>");
+            // check if it is really a file.
+            if (stats.isFile()) { // is a file.
+                fs_ext = path.extname(filename).split(".")[1];
+                if (!mimeTypes[fs_ext]) { // raise 404 if ext not supported.
+                    send_not_found(res);
+                    return;
+                }
+
+                // read and send file
+                fs.readFile(filename, function (err, data) {
+                    if (err) { // file not readable. throw 404.
+                        send_not_found(res);
+                        return;
+                    }
+
+                    res.writeHead(200, {
+                        "Content-Type": mimeTypes[fs_ext],
+                        "Content-Length": data.length
+                    });
+                    res.end(data);
+                });
+            } else { // (stats.isFile())
+                // not a file. just throw a 404.
+                send_not_found(res);
                 return;
             }
-
-            // serve static file if exists and supported.
-            res.writeHead(200, mimeTypes[fs_ext]);
-            fs.createReadStream(filename).pipe(res);
         });
     }
 }).listen(serverPort, function () {
@@ -101,29 +124,30 @@ function proxy(client_req, client_res) {
         opts.cert = fs.readFileSync(cert_file);
     }
 
+
     client_req.pipe(requester(opts, function (res) {
-            // if etcd returns that the requested  page  has been moved
-            // to a different location, indicates that the node we are
-            // querying is not the leader. This will redo the request
-            // on the leader which is reported by the Location header
-            if (res.statusCode === 307) {
-                opts.hostname = url.parse(res.headers['location']).hostname;
-                client_req.pipe(requester(opts, function (res) {
-                        console.log('Got response: ' + res.statusCode);
-                        res.pipe(client_res, {
-                            end: true
-                        });
-                    }, {
-                        end: true
-                    }));
-            } else {
+        // if etcd returns that the requested  page  has been moved
+        // to a different location, indicates that the node we are
+        // querying is not the leader. This will redo the request
+        // on the leader which is reported by the Location header
+        if (res.statusCode === 307) {
+            opts.hostname = url.parse(res.headers['location']).hostname;
+            client_req.pipe(requester(opts, function (res) {
+                console.log('Got response: ' + res.statusCode);
                 res.pipe(client_res, {
                     end: true
                 });
-            }
-        }, {
-            end: true
-        }));
+            }, {
+                end: true
+            }));
+        } else {
+            res.pipe(client_res, {
+                end: true
+            });
+        }
+    }, {
+        end: true
+    }));
 }
 
 function auth(req, res) {


### PR DESCRIPTION
- Normalize request path before checking file path.
- Checks if file MIME type is supported before getting file content.
- Adds `Content-Length` headers on response.
- Checks and throws 404 if request path is directory.