### PR TITLE
Fix: docker-compose always deploys using etcd-browser:latest image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       "--listen-client-urls", "http://0.0.0.0:2379",
       "--initial-cluster", "etcd=http://${NODE_ADDR}:2380" ]
   browser:
-    image: etcd-browser:latest
+    image: ${ETCD_BROWSER_IMAGE}
     ports:
       - "8000:8000"
     environment:


### PR DESCRIPTION
now browser image correctly uses script image.